### PR TITLE
add trans scripts

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -228,10 +228,17 @@ type Overridables struct {
 
 // RPM is custom configs that are only available on RPM packages.
 type RPM struct {
+	Scripts     RPMScripts   `yaml:"scripts,omitempty"`
 	Group       string       `yaml:"group,omitempty"`
 	Summary     string       `yaml:"summary,omitempty"`
 	Compression string       `yaml:"compression,omitempty"`
 	Signature   RPMSignature `yaml:"signature,omitempty"`
+}
+
+// RPMScripts represents scripts only available on RPM packages.
+type RPMScripts struct {
+	PreTrans  string `yaml:"pretrans,omitempty"`
+	PostTrans string `yaml:"posttrans,omitempty"`
 }
 
 type PackageSignature struct {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -266,6 +266,13 @@ func toRelation(items []string) (rpmpack.Relations, error) {
 }
 
 func addScriptFiles(info *nfpm.Info, rpm *rpmpack.RPM) error {
+	if info.RPM.Scripts.PreTrans != "" {
+		data, err := ioutil.ReadFile(info.RPM.Scripts.PreTrans)
+		if err != nil {
+			return err
+		}
+		rpm.AddPretrans(string(data))
+	}
 	if info.Scripts.PreInstall != "" {
 		data, err := ioutil.ReadFile(info.Scripts.PreInstall)
 		if err != nil {
@@ -296,6 +303,14 @@ func addScriptFiles(info *nfpm.Info, rpm *rpmpack.RPM) error {
 			return err
 		}
 		rpm.AddPostun(string(data))
+	}
+
+	if info.RPM.Scripts.PostTrans != "" {
+		data, err := ioutil.ReadFile(info.RPM.Scripts.PostTrans)
+		if err != nil {
+			return err
+		}
+		rpm.AddPosttrans(string(data))
 	}
 
 	return nil

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -76,6 +76,12 @@ func exampleInfo() *nfpm.Info {
 				PreRemove:   "../testdata/scripts/preremove.sh",
 				PostRemove:  "../testdata/scripts/postremove.sh",
 			},
+			RPM: nfpm.RPM{
+				Scripts: nfpm.RPMScripts{
+					PreTrans:  "../testdata/scripts/pretrans.sh",
+					PostTrans: "../testdata/scripts/posttrans.sh",
+				},
+			},
 		},
 	})
 }
@@ -366,6 +372,22 @@ echo "Postinstall" > /dev/null
 
 echo "Postremove" > /dev/null
 `, data, "Postremove script does not match")
+
+	rpmPreTransTag := 1151
+	data, err = rpm.Header.GetString(rpmPreTransTag)
+	require.NoError(t, err)
+	assert.Equal(t, `#!/bin/bash
+
+echo "Pretrans" > /dev/null
+`, data, "Pretrans script does not match")
+
+	rpmPostTransTag := 1152
+	data, err = rpm.Header.GetString(rpmPostTransTag)
+	require.NoError(t, err)
+	assert.Equal(t, `#!/bin/bash
+
+echo "Posttrans" > /dev/null
+`, data, "Posttrans script does not match")
 }
 
 func TestRPMFileDoesNotExist(t *testing.T) {

--- a/testdata/acceptance/complex.386.yaml
+++ b/testdata/acceptance/complex.386.yaml
@@ -33,4 +33,7 @@ scripts:
   postinstall: ./testdata/acceptance/scripts/postinstall.sh
   preremove: ./testdata/acceptance/scripts/preremove.sh
   postremove: ./testdata/acceptance/scripts/postremove.sh
-
+rpm:
+  scripts:
+    pretrans: ./testdata/acceptance/scripts/pretrans.sh
+    posttrans: ./testdata/acceptance/scripts/posttrans.sh

--- a/testdata/acceptance/complex.yaml
+++ b/testdata/acceptance/complex.yaml
@@ -35,3 +35,7 @@ scripts:
   postinstall: ./testdata/acceptance/scripts/postinstall.sh
   preremove: ./testdata/acceptance/scripts/preremove.sh
   postremove: ./testdata/acceptance/scripts/postremove.sh
+rpm:
+  scripts:
+    pretrans: ./testdata/acceptance/scripts/pretrans.sh
+    posttrans: ./testdata/acceptance/scripts/posttrans.sh

--- a/testdata/acceptance/rpm.386.complex.dockerfile
+++ b/testdata/acceptance/rpm.386.complex.dockerfile
@@ -14,6 +14,8 @@ RUN test -d /var/log/whatever
 RUN test -d /usr/share/foo
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
+RUN test -f /tmp/pretrans-proof
+RUN test -f /tmp/posttrans-proof
 RUN test ! -f /tmp/preremove-proof
 RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf

--- a/testdata/acceptance/rpm.complex.dockerfile
+++ b/testdata/acceptance/rpm.complex.dockerfile
@@ -17,6 +17,8 @@ RUN test -d /var/log/whatever
 RUN test -d /usr/share/foo
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
+RUN test -f /tmp/pretrans-proof
+RUN test -f /tmp/posttrans-proof
 RUN test ! -f /tmp/preremove-proof
 RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf

--- a/testdata/acceptance/scripts/posttrans.sh
+++ b/testdata/acceptance/scripts/posttrans.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Ok" > /tmp/posttrans-proof

--- a/testdata/acceptance/scripts/pretrans.sh
+++ b/testdata/acceptance/scripts/pretrans.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Ok" > /tmp/pretrans-proof

--- a/testdata/scripts/posttrans.sh
+++ b/testdata/scripts/posttrans.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Posttrans" > /dev/null

--- a/testdata/scripts/pretrans.sh
+++ b/testdata/scripts/pretrans.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Pretrans" > /dev/null


### PR DESCRIPTION
This PR adds %pretrans and %posttrans scriptlets to rpm pkg.

pretrans and posttrans are run at start and end of a transaction.
On upgrade, the scripts are run in the following order:

%pretrans of new package
%pre of new package
(package install)
%post of new package
%preun of old package
(removal of old package)
%postun of old package
%posttrans of new package